### PR TITLE
Nice numbers via Unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@ Humanize.jl
 ===========
 
 [![Build Status](https://travis-ci.org/IainNZ/Humanize.jl.svg?branch=master)](https://travis-ci.org/IainNZ/Humanize.jl)
-[![codecov](https://codecov.io/gh/IainNZ/Humanize.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/IainNZ/Humanize.jl)
+[![codecov.io](http://codecov.io/github/IainNZ/Humanize.jl/coverage.svg?branch=master)](http://codecov.io/github/IainNZ/Humanize.jl?branch=master)
 
-[![Humanize](http://pkg.julialang.org/badges/Humanize_0.4.svg)](http://pkg.julialang.org/?pkg=Humanize)
-[![Humanize](http://pkg.julialang.org/badges/Humanize_0.5.svg)](http://pkg.julialang.org/?pkg=Humanize)
+[![Humanize](http://pkg.julialang.org/badges/Humanize_0.3.svg)](http://pkg.julialang.org/?pkg=Humanize&ver=release)
+[![Humanize](http://pkg.julialang.org/badges/Humanize_0.4.svg)](http://pkg.julialang.org/?pkg=Humanize&ver=nightly)
 
 Humanize numbers, including
 * data sizes (`3e6 -> 3.0 MB or 2.9 MiB`).
 * Date/datetime differences (`Date(2014,2,3) - Date(2013,3,7) -> 1 year, 1 month`)
 * Digit separator (`12345678 -> 12,345,678`)
+* Prettification of numbers (`1988.12345678 -> 1.988⋅10³`)
 
 This package is MIT licensed, and is based on [jmoiron's humanize Python library](https://github.com/jmoiron/humanize/).
 
@@ -53,7 +54,7 @@ julia> timedelta(70)
 "a minute"
 julia> timedelta(0,0,0,23,50,50)
 "23 hours"
-julia> timedelta(DateTime(2014,2,3,12,11,10) - 
+julia> timedelta(DateTime(2014,2,3,12,11,10) -
                     DateTime(2013,3,7,13,1,20))
 "11 months"
 julia> timedelta(Date(2014,3,7) - Date(2013,2,4))
@@ -69,4 +70,16 @@ julia> digitsep(12345678, sep = "'")
 "12'345'678"
 julia> digitsep(12345678, sep = "-", k = 4)
 "1234-5678"
+```
+
+
+### Nice numbers
+
+```julia
+julia> nicenumber("ρ ≃ 00.04 ± 2e-3")
+"ρ ≃ 0.04 ± 0.002"
+julia> nicenumber("-100000000")
+"-1⋅10⁸"
+julia> nicenumber(-1e20)
+"-1⋅10²⁰"
 ```

--- a/src/Humanize.jl
+++ b/src/Humanize.jl
@@ -9,7 +9,7 @@ isdefined(Base, :__precompile__) && __precompile__()
 
 module Humanize
 
-export datasize, timedelta, digitsep
+export datasize, timedelta, digitsep, nicenumber
 
 #---------------------------------------------------------------------
 const dec_suf = [" B", " kB", " MB", " GB", " TB", " PB", " EB", " ZB", " YB"]
@@ -65,7 +65,7 @@ function timedelta(secs::Integer)
     days   = div( hours, 24); hours  -= 24*days
     months = div(  days, 30); days   -= 30*months
     years  = div(months, 12); months -= 12*years
-    
+
     if years == 0
         if days == 0 && months == 0
             hours >= 1 && return hours == 1 ? "an hour"  : "$hours hours"
@@ -112,5 +112,7 @@ function digitsep(value::Integer, sep = ",", k = 3)
     groups = [value[max(x-k+1, 1):x] for x in starts]
     return join(groups, sep)
 end
+
+include("nicenumbers.jl")
 
 end

--- a/src/nicenumbers.jl
+++ b/src/nicenumbers.jl
@@ -1,0 +1,173 @@
+# Print numbers nicely. For example,
+# 1988.12345678 gets printed as "1.988⋅10³"
+
+############################
+#                          #
+#      Default options     #
+#                          #
+############################
+
+const max_int_len = 5
+const max_whole_part_len = 3
+const max_decimals = 3
+
+############################
+#                          #
+#         Unicode          #
+#                          #
+############################
+
+const supers = [  '⁰'; '¹'; '²'
+                ; '³'; '⁴'; '⁵'
+                ; '⁶'; '⁷'; '⁸'
+                ; '⁹']
+
+const superminus = '⁻'
+
+############################
+#                          #
+#        Functions         #
+#                          #
+############################
+
+# Get mantissa and exponent
+
+exponent(x::Number) = floor(Int64,log10(abs(x)))
+
+function mantissa(x::Number)
+    for i in 1:abs(exponent(x))
+        if sign(exponent(x)) == +1
+        x /= 10.0
+        else
+        x *= 10.0
+        end
+    end
+    return x
+end
+
+# Superindex generator
+
+function integer_to_sup(x::Integer)
+    str = dec(abs(x))
+    L = length(str)
+    sups = Array(Char,L)
+    for i in 1:L
+        c = str[i]
+        n = Int64(c) - 48
+        sups[i] = supers[n+1]
+    end
+    result = String(sups)
+    if x > 0
+        return result
+    else
+        return "$superminus$result"
+    end
+end
+
+# Pretty print in scientific notation
+function scientific(x::Number; l=:full, hideexp=true)
+    m = mantissa(abs(x)) |> string
+    # Sign will be added later.
+    if l == :full
+        mstr = m[1:end]
+    elseif l == 0
+        mstr = m[1]
+    elseif l ≥ 1
+        # - 2 because the first number and the point.
+        if l > length(m) - 2 # needs padding
+            pad = fill('0',l-length(m)+2) |> join
+            mstr = string(m,pad)
+        else
+            mstr = string(m)[1:l+2]
+        end
+    else
+        error("l ∉ [0,∞). Use :full for all places")
+    end
+    expstr = x |> exponent |> integer_to_sup
+    if x < 0
+        mstr = string('-',mstr)
+    end
+    if hideexp && exponent(x) == 0
+        return string(mstr)
+    else
+        return string(mstr,"⋅10",expstr)
+    end
+end
+
+# Number of significant digits. 1.420 has 4, for
+# example. 0.0540 has 3.
+function sig_digits(x::AbstractString)
+    # remove sign and exponent
+    x = replace(x,r"e.*","")
+    x = replace(x,"+","")
+    x = replace(x,"-","")
+    # remove leading zeroes and possible dot
+    x = replace(x,r"^0*\.?0*","")
+    # remove point so we dont count it as character
+    x = replace(x,".","")
+    return length(x)
+end
+sig_digits(x::Number) = x |> string |> sig_digits
+
+
+"""
+    nicenumber(x::Number)
+
+Change `x` by a nice looking number. Returns a string.
+"""
+function nicenumber(x::Number)
+    if isinteger(x) && exponent(x) < max_int_len
+        char_size = exponent(x) + 1
+        if char_size ≤ max_int_len
+            return @sprintf("%d",x)
+        else # Scientific notation
+            return scientific(x,l=0)
+        end
+    else # It's a float
+        whole = floor(x)
+        decimal = x - floor(x)
+        whole_part_len = @sprintf("%d",abs(whole)) |> length
+        decimal_part_len = sig_digits(x) - whole_part_len
+        # Small enough, don't touch it.
+        if whole_part_len ≤ max_whole_part_len && round(x,max_decimals) ≠ 0
+            if decimal_part_len ≤ max_decimals
+                return string(x)
+            else #truncate decimals
+                return round(x, max_decimals) |> string
+            end
+        elseif x / 10.0^exponent(x) ≈ round(mantissa(x))
+            # Just an "int". Does not need decimals.
+            # An example is 5e-5, is just 5⋅10⁻⁵.
+            superindex = x |> exponent |> integer_to_sup
+            whole = round(x / 10.0^exponent(x))
+            return @sprintf("%d⋅10%s",mantissa(x) ,superindex)
+        else # Too big and not an pseudoint. To scientific.
+            dec_places = min(sig_digits(x)-1, max_decimals)
+            return scientific(x,l=dec_places)
+        end
+    end
+end
+
+# This function transforms a string into a nice
+# looking one, by changing all his numbers to
+# pretty ones.
+"""
+    nicenumber(str::AbstractString)
+
+Change all the numbers in str by nice looking ones.
+"""
+function nicenumber(str::AbstractString)
+    # Search for numbers in the string, and
+    # substitute them.
+    num_r = r"[+-]?\d{1,}\.?\d*e?[+-]?\d*"
+    # Regex explanation:
+    # ±?  num(1,∞)  .?  num(0,∞)  e? ±?  num(0,∞)
+    # +     2       .   4254      e  -   20
+    # +2.4254e-20 (e.g.)
+    result = str # will be overwriten
+    for numstr in matchall(num_r,str)
+        value = parse(Float64,numstr)
+        result = replace(result, numstr, nicenumber(value))
+    end
+    return result
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ function test_digitsep()
             (1234567, "1,234,567"),
             (12345678, "12,345,678")
             )
-    
+
     n_test = length(test)
 
     #digitsep(value::Integer)
@@ -93,9 +93,67 @@ function test_digitsep()
     for t in test
         @test digitsep(t[1]) == t[2]
     end
-    
+
+end
+
+function test_nicenumbers()
+    println("test_nicenumbers")
+
+    # Integers
+    @test nicenumber(1) == "1"
+    @test nicenumber(-11111) == "-11111"
+    @test nicenumber(-1e4) == "-10000"
+    @test nicenumber(+1e6) == "1⋅10⁶"
+    @test nicenumber(-1e6) == "-1⋅10⁶"
+    @test nicenumber(-5e+60) == "-5⋅10⁶⁰"
+    # Floating point
+    @test nicenumber(3e-4) == "3⋅10⁻⁴"
+    @test nicenumber(1.289e2) == "128.9"
+    @test nicenumber(1.22e1) == "12.2"
+    @test nicenumber(0.22e1) == "2.2"
+    @test nicenumber(1.12345678) == "1.123"
+    @test nicenumber(198.12345678) == "198.123"
+    @test nicenumber(1988.12345678) == "1.988⋅10³"
+    @test nicenumber(0.00000198812345678) == "1.988⋅10⁻⁶"
+
+    # General tests
+    @test "1"                  |> nicenumber == "1"
+    @test "01"                 |> nicenumber == "1"
+    @test "010"                |> nicenumber == "10"
+    @test "100000000"          |> nicenumber == "1⋅10⁸"
+    @test "1e20"               |> nicenumber == "1⋅10²⁰"
+    @test "1e2"                |> nicenumber == "100"
+    @test "+1"                 |> nicenumber == "1"
+    @test "+01"                |> nicenumber == "1"
+    @test "+010"               |> nicenumber == "10"
+    @test "+100000000"         |> nicenumber == "1⋅10⁸"
+    @test "+1e20"              |> nicenumber == "1⋅10²⁰"
+    @test "+1e+2"              |> nicenumber == "100"
+    @test "-1"                 |> nicenumber == "-1"
+    @test "-01"                |> nicenumber == "-1"
+    @test "-010"               |> nicenumber == "-10"
+    @test "-100000000"         |> nicenumber == "-1⋅10⁸"
+    @test "-1e20"              |> nicenumber == "-1⋅10²⁰"
+    @test "-1e-2"              |> nicenumber == "-0.01"
+    @test "+1.42"              |> nicenumber == "1.42"
+    @test "-01.42"             |> nicenumber == "-1.42"
+    @test "+010.42"            |> nicenumber == "10.42"
+    @test "-100000.42"         |> nicenumber == "-1.000⋅10⁵"
+    @test "2.42e-20"           |> nicenumber == "2.42⋅10⁻²⁰"
+    @test "-0.000000242"       |> nicenumber == "-2.42⋅10⁻⁷"
+    @test "+0.000000242"       |> nicenumber == "2.42⋅10⁻⁷"
+
+    @test "ρ ≃ 0.4 ± 2e-5"     |> nicenumber == "ρ ≃ 0.4 ± 2⋅10⁻⁵"
+    @test "ρ ≃ 00.04 ± 2e-3"   |> nicenumber == "ρ ≃ 0.04 ± 0.002"
+    @test "γ=4.05e-20, β=5e-3" |> nicenumber == "γ=4.05⋅10⁻²⁰, β=0.005"
+    @test "∫σ dx = 0.00004"    |> nicenumber == "∫σ dx = 4⋅10⁻⁵"
+
+    # Escaping sequences.
+    num = Float64(π)
+    @test nicenumber("$num") == "3.142"
 end
 
 test_datasize()
 test_timedelta()
 test_digitsep()
+test_nicenumbers()


### PR DESCRIPTION
This pull request adds functionality to the package so it's able to "prettify" big ugly numbers. It's explained better with some examples:

```julia
"ρ ≃ 0.4 ± 2e-5"     |> nicenumber == "ρ ≃ 0.4 ± 2⋅10⁻⁵"
"ρ ≃ 00.04 ± 2e-3"   |> nicenumber == "ρ ≃ 0.04 ± 0.002"
"γ=4.05e-20, β=5e-3" |> nicenumber == "γ=4.05⋅10⁻²⁰, β=0.005"
"∫σ dx = 0.00004"    |> nicenumber == "∫σ dx = 4⋅10⁻⁵"
```

It also works with numerical values:


```julia
nicenumber(198.12345678) == "198.123"
nicenumber(1988.12345678) == "1.988⋅10³"
nicenumber(0.00000198812345678) == "1.988⋅10⁻⁶"
```

I have also made extensive tests of the functionality, you can see more examples in `runtests.jl`.